### PR TITLE
Update GitHub Actions workflow for testing

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -10,31 +10,30 @@ on:
 
 jobs:
   test:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: '18.17.0'
-
+        node-version: lts/*
     - name: Install dependencies
       run: npm install
-
-    - name: Install Playwright browsers
-      run: npx playwright install
-
-    - name: Build the application
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Build the app
       run: npm run build
-
-    - name: Start the application
-      run: npm start &
-    
-    - name: Wait for the application to be ready
-      run: npx wait-on http://localhost:3000
-
-    - name: Run Jest tests
+    - name: Start the server in the background
+      run: |
+        npm start &
+        npx wait-on http://localhost:3000
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30
+    - name: Run Tests
       run: npm test


### PR DESCRIPTION
- Upgrade actions to latest versions (checkout@v4, setup-node@v4)
- Set Node.js to use latest LTS version
- Increase workflow timeout to 60 minutes
- Add Playwright browser installation with dependencies
- Improve test workflow with artifact upload for Playwright reports
- Standardize npm commands and workflow steps